### PR TITLE
Insert new zones at bank index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,5 @@ accessories
 accessories/*
 .vscode
 .vscode/*
+
+.DS_Store

--- a/src/NX595ESecuritySystem.ts
+++ b/src/NX595ESecuritySystem.ts
@@ -377,7 +377,7 @@ export class NX595ESecuritySystem {
         autoBypass: false
       };
 
-      this.zones.push(newZone);
+      this.zones[i] = newZone;
     });
 
     this.processZones();


### PR DESCRIPTION
I'd suggest to insert each zone at their bank number, instead of pushing it to the zones array.

This fixes `TypeError: Cannot read property 'bank_state' of undefined` at line 580.
Now you can retrieve zones without crashing.

However, there's still an error when processing the retrieved zones.
`this._zvbank[zone.bank]` at line 411 is undefined if it's a dead zone.